### PR TITLE
Remove additional `--update` for apk in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM python:3-alpine3.21
 
 # Combine related APK commands to reduce image layers and cleanup cache
-RUN apk add --no-cache --update \
+RUN apk add --no-cache \
     postgresql-client \
     util-linux \
     bash && \


### PR DESCRIPTION
There is no need to use `--update` with `--no-cache` when using `apk` on Alpine Linux, as using `--no-cache` will fetch the index every time and leave no local cache, so the index will always be the latest without temporary files remain in the image.